### PR TITLE
fix: Resolve CS0136 error in JerryCan refueling logic

### DIFF
--- a/FuelSystem.cs
+++ b/FuelSystem.cs
@@ -580,7 +580,7 @@ public class RealisticFuelSystem : Script
         // Gérer le ravitaillement avec jerrycan en cours
         if (isRefuelingWithJerryCan && currentJerryCanRefuelVehicle != null && currentJerryCanRefuelVehicle.Exists())
         {
-            Ped playerPed = Game.Player.Character;
+            // Ped playerPed = Game.Player.Character; // CS0136 Error: Already defined in this scope (at the start of OnTick)
 
             // Distance Check
             if (playerPed.Position.DistanceTo(currentJerryCanRefuelVehicle.Position) > 5.0f)


### PR DESCRIPTION
Corrects a CS0136 build error caused by a redundant declaration of the `playerPed` variable within the `isRefuelingWithJerryCan` block in the `OnTick` method of `FuelSystem.cs`.

The inner declaration was removed, and the logic now uses the `playerPed` variable defined in the outer scope of the `OnTick` method. This resolves the naming conflict and allows the project to build successfully, while maintaining the intended functionality of the continuous JerryCan refueling feature.