### PR TITLE
Fix: Address build errors and API incompatibilities in NPCRoadRage sc…

### DIFF
--- a/NPCRoadRage.cs
+++ b/NPCRoadRage.cs
@@ -1,11 +1,12 @@
 using GTA;
-using GTA.Native;
+using GTA.Native; // Required for Hash and Function.Call
 using GTA.Math;
+using GTA.UI; 
 using System;
 using System.Windows.Forms;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Linq; // Required for LINQ's Where method
 using System.Drawing;
 
 public class NPCRoadRage : Script 
@@ -13,7 +14,7 @@ public class NPCRoadRage : Script
     // --- Configuration (easily updatable) ---
     private readonly TimeSpan _npcCollisionCooldownDuration = TimeSpan.FromSeconds(10);
     private readonly TimeSpan _npcReactionTimeoutDuration = TimeSpan.FromSeconds(30);
-    private readonly TimeSpan _policeDispatchTimeoutDuration = TimeSpan.FromSeconds(90); // Timeout for police to arrive
+    private readonly TimeSpan _policeDispatchTimeoutDuration = TimeSpan.FromSeconds(90); 
     private readonly TimeSpan _policeExitVehicleTimeoutDuration = TimeSpan.FromSeconds(10);
     private readonly TimeSpan _policeApproachTimeoutDuration = TimeSpan.FromSeconds(15);
     private readonly TimeSpan _policeInteractionDialoguePauseDuration = TimeSpan.FromSeconds(3);
@@ -27,17 +28,19 @@ public class NPCRoadRage : Script
     private VehicleHash _policeVehicleModel = VehicleHash.Police;
     private const float PoliceArrivalDistanceThreshold = 15.0f; 
     private const float OfficerApproachDistanceThreshold = 5.0f; 
-    private const float MaxInteractionDistance = 40.0f; // Increased slightly
+    private const float MaxInteractionDistance = 40.0f; 
+    private const float PoliceDriveSpeed = 30.0f; 
+    private const float PolicePatrolSpeed = 20.0f; 
 
     // --- State Fields ---
     private Dictionary<int, DateTime> _npcCollisionCooldowns = new Dictionary<int, DateTime>();
-    private Ped _collidedNpcPed;
-    private Vehicle _collidedNpcVehicle; 
-    private Vector3 _incidentLocation; 
+    private Ped? _collidedNpcPed = null;
+    private Vehicle? _collidedNpcVehicle = null; 
+    private Vector3 _incidentLocation = Vector3.Zero; 
     private bool _npcReacting = false;
     private enum NpcReactionType { None, Aggressive, CallPolice }
     private NpcReactionType _currentReaction = NpcReactionType.None;
-    private DateTime _stateTimer; // Generic timer for various states
+    private DateTime _stateTimer; 
 
     public static bool PoliceCalled = false; 
     private bool _policeDispatched = false; 
@@ -50,43 +53,39 @@ public class NPCRoadRage : Script
 
     private Random _random = new Random();
     private List<Ped> _respondingPolicePeds = new List<Ped>();
-    private Vehicle _policeVehicle;
+    private Vehicle? _policeVehicle = null;
     private string _playerResponse = string.Empty;
 
     public NPCRoadRage()
     {
         Tick += OnTick;
         KeyDown += OnKeyDown; 
-        Log("NPCRoadRage script loaded. Version 1.6 - Refinements.");
-        _incidentLocation = Vector3.Zero; 
+        Log("NPCRoadRage script loaded. Version 1.11 - Argument Mismatch Fixes.");
     }
 
     private void OnTick(object sender, EventArgs e)
     {
         Ped player = Game.Player.Character;
 
-        // 1. Global Pre-checks
-        if (Game.IsLoading || Game.IsCutsceneActive || player == null || !player.Exists() || player.IsDead)
+        if (Game.IsCutsceneActive || player == null || !player.Exists() || player.IsDead)
         {
             if(_policeDispatched || _npcReacting || _policeInteractionActive || _makingPoliceDecision) {
-                Log("Game state changed (loading/cutscene/player dead). Forcing cleanup of active incident.");
+                Log("Game state changed (cutscene/player dead). Forcing cleanup of active incident.");
                 FullResetOfScriptStates(); 
             }
             return;
         }
 
-        // Abort interaction if player runs too far away
         if ((_policeInteractionActive || _makingPoliceDecision) && _policeVehicle != null && _policeVehicle.Exists()) {
             if (player.Position.DistanceTo(_policeVehicle.Position) > MaxInteractionDistance) {
                 Log("Player moved too far during police interaction. Aborting and cleaning up.");
-                UI.Notify("You left the scene of the incident.");
-                EndPoliceInteraction(false, true); // playerFled = true
+                GTA.UI.Screen.ShowNotification("You left the scene of the incident.");
+                EndPoliceInteraction(false, true); 
                 return;
             }
         }
 
-        // --- Main State Machine ---
-        if (PoliceCalled && !_policeDispatched && !_policeInteractionActive && !_makingPoliceDecision && !_policeArrived) // Ensure not arrived either
+        if (PoliceCalled && !_policeDispatched && !_policeInteractionActive && !_makingPoliceDecision && !_policeArrived)
         {
             Log("PoliceCalled is true and police not yet dispatched. Initiating police response.");
             Vector3 locationForPolice = (_incidentLocation != Vector3.Zero) ? _incidentLocation : player.Position;
@@ -110,38 +109,38 @@ public class NPCRoadRage : Script
         }
         else 
         {
-            // Idle state: Safe to check for new collisions
-            // Safeguard, should be covered by FullReset elsewhere.
-            if (_policeDispatched || _policeArrived || PoliceCalled) {
-                 // If PoliceCalled is true but nothing else, DispatchPolice should trigger.
-                 // If _policeDispatched or _policeArrived is true, something is wrong, reset.
-                 if((_policeDispatched || _policeArrived) && !PoliceCalled) { // Anomaly if dispatched/arrived but no call active
-                    Log("Anomaly detected: Police dispatched/arrived but PoliceCalled is false. Resetting.");
+            if (_policeDispatched || _policeArrived) {
+                 if((_policeDispatched || _policeArrived) && !PoliceCalled && !_makingPoliceDecision && !_policeInteractionActive) { 
+                    Log("Anomaly detected: Police dispatched/arrived but no incident active. Resetting.");
                     FullResetOfScriptStates();
                  }
                  return;
             }
 
+            Vehicle playerVeh = player.CurrentVehicle; // Renamed for clarity in this scope
+            if (playerVeh == null) return;
 
-            Vehicle playerVehicle = player.CurrentVehicle;
-            if (playerVehicle == null) return;
+            // Corrected World.GetNearbyVehicles usage
+            Vehicle[] nearbyVehicles = World.GetNearbyVehicles(playerVeh.Position, 7.0f)
+                                             .Where(v => v != null && v.Exists() && v != playerVeh)
+                                             .ToArray();
 
-            Vehicle[] nearbyVehicles = World.GetNearbyVehicles(playerVehicle.Position, 7.0f, playerVehicle);
             foreach (Vehicle npcVehicle in nearbyVehicles)
             {
-                if (npcVehicle == null || !npcVehicle.Exists()) continue;
+                // No need for npcVehicle == null || !npcVehicle.Exists() due to Where clause, but keeping for safety if Where is removed.
+                if (npcVehicle == null || !npcVehicle.Exists()) continue; 
                 if (_npcCollisionCooldowns.ContainsKey(npcVehicle.Handle) && DateTime.Now < _npcCollisionCooldowns[npcVehicle.Handle]) continue;
                 
                 Ped npcDriver = npcVehicle.Driver;
                 if (npcDriver != null && npcDriver.Exists() && npcDriver.IsHuman && !npcDriver.IsPlayer)
                 {
-                    bool isTouching = playerVehicle.IsTouching(npcVehicle);
-                    bool playerDamagedNpc = playerVehicle.HasBeenDamagedBy(npcVehicle); 
-                    bool npcDamagedPlayer = npcVehicle.HasBeenDamagedBy(playerVehicle);
+                    bool isTouching = playerVeh.IsTouching(npcVehicle); // Use playerVeh
+                    bool playerDamagedNpc = playerVeh.HasBeenDamagedBy(npcVehicle); // Use playerVeh
+                    bool npcDamagedPlayer = npcVehicle.HasBeenDamagedBy(playerVeh); // Use playerVeh
 
                     if (isTouching && (playerDamagedNpc || npcDamagedPlayer))
                     {
-                        Log($"Collision detected: PlayerVehicle ({playerVehicle.Model.Hash}) with NPCDriver ({npcDriver.Model.Hash}) in NPCVehicle ({npcVehicle.Model.Hash}).");
+                        Log($"Collision detected: PlayerVehicle ({playerVeh.Model.Hash}) with NPCDriver ({npcDriver.Model.Hash}) in NPCVehicle ({npcVehicle.Model.Hash}).");
                         if (!npcDriver.IsInVehicle(npcVehicle) || npcDriver.IsDead || npcDriver.IsInjured) {
                              Log("NPC no longer valid for reaction (not in vehicle or dead/injured). Applying cooldown.");
                             _npcCollisionCooldowns[npcVehicle.Handle] = DateTime.Now + _npcCollisionCooldownDuration;
@@ -151,9 +150,7 @@ public class NPCRoadRage : Script
                         FullResetOfScriptStates(); 
 
                         _collidedNpcPed = npcDriver;
-                        // _collidedNpcPed.IsPersistent = true; // Decided against for now, use MarkAsNoLongerNeeded on cleanup
                         _collidedNpcVehicle = npcVehicle; 
-                        // _collidedNpcVehicle.IsPersistent = true;
 
                         _incidentLocation = npcVehicle.Position; 
                         _npcReacting = true;
@@ -164,7 +161,7 @@ public class NPCRoadRage : Script
                         
                         Log($"NPC {_collidedNpcPed.Handle} reacting: {_currentReaction} at {_incidentLocation}");
                         _npcCollisionCooldowns[npcVehicle.Handle] = DateTime.Now + _npcCollisionCooldownDuration;
-                        UI.Notify($"NPC {npcDriver.Handle} is reacting to collision!");
+                        GTA.UI.Screen.ShowNotification($"NPC {npcDriver.Handle} is reacting to collision!");
                         ProcessNpcReaction(); 
                         return; 
                     }
@@ -186,50 +183,42 @@ public class NPCRoadRage : Script
             return;
         }
 
-        if (_collidedNpcPed.IsInVehicle(_collidedNpcVehicle) && _collidedNpcVehicle.Exists())
+        bool isLeavingVehicleTaskActive = Function.Call<bool>(Hash.GET_IS_TASK_ACTIVE, _collidedNpcPed.Handle, 4); 
+
+        if (_collidedNpcVehicle != null && _collidedNpcVehicle.Exists() && _collidedNpcPed.IsInVehicle(_collidedNpcVehicle))
         {
-            if (!_collidedNpcPed.IsGettingOutOfVehicle)
+            if (!isLeavingVehicleTaskActive) 
             {
-                bool isLeavingVehicle = false;
-                if (_collidedNpcPed.Tasks.CurrentTask != null) {
-                    int taskHash = _collidedNpcPed.Tasks.CurrentTask.Hash;
-                    if (taskHash == Game.GenerateHash("TASK_LEAVE_VEHICLE") || taskHash == Game.GenerateHash("CTaskLeaveVehicle")) isLeavingVehicle = true;
-                }
-                if (!isLeavingVehicle)
-                {
-                    Log($"Telling NPC {_collidedNpcPed.Handle} to leave vehicle {_collidedNpcVehicle.Handle}.");
-                    _collidedNpcPed.Tasks.LeaveVehicle(_collidedNpcVehicle, false); 
-                    // Allow some time for task to start, next tick will check IsGettingOutOfVehicle or if still in vehicle
-                }
+                Log($"Telling NPC {_collidedNpcPed.Handle} to leave vehicle {_collidedNpcVehicle.Handle}.");
+                _collidedNpcPed.Task.LeaveVehicle(_collidedNpcVehicle, false); 
             }
-             // If still in vehicle (or getting out), wait for next tick.
-            if (_collidedNpcPed.IsInVehicle(_collidedNpcVehicle)) return;
+            if (_collidedNpcPed.IsInVehicle(_collidedNpcVehicle) || isLeavingVehicleTaskActive) return;
         }
         
         switch (_currentReaction)
         {
             case NpcReactionType.Aggressive:
                 Log($"NPC {_collidedNpcPed.Handle} is out of vehicle. Becoming aggressive towards player.");
-                _collidedNpcPed.Tasks.ClearAll(); 
-                _collidedNpcPed.Task.FightAgainst(Game.Player.Character);
+                _collidedNpcPed.Task.ClearAll(); 
+                _collidedNpcPed.Task.Combat(Game.Player.Character, 0, 0); 
                 ResetNpcReactionState(); 
                 break;
             case NpcReactionType.CallPolice:
                 Log($"NPC {_collidedNpcPed.Handle} is out of vehicle. Attempting to call police.");
-                _collidedNpcPed.Tasks.ClearAll();
-                // Simple cower and then set flag. More complex animations could be timed with _stateTimer.
-                if (_collidedNpcPed.Tasks.CurrentTask?.Hash != Game.GenerateHash("TASK_COWER")) {
-                     _collidedNpcPed.Tasks.Cower(-1); 
+                _collidedNpcPed.Task.ClearAll();
+                uint taskCowerHash = (uint)Function.Call<int>(Hash.GET_HASH_KEY, "TASK_COWER");
+                if (_collidedNpcPed.Task.CurrentTask?.Hash != taskCowerHash) { 
+                     _collidedNpcPed.Task.Cower(-1); 
                      Log($"NPC {_collidedNpcPed.Handle} is cowering. Will 'call police' next tick conceptually.");
                 } else {
                     if (!PoliceCalled) 
                     {
-                        PoliceCalled = true; // Set the global flag
-                        _stateTimer = DateTime.Now; // Reset timer, now for police dispatch timeout
+                        PoliceCalled = true; 
+                        _stateTimer = DateTime.Now; 
                         Log($"PoliceCalled flag set to true by NPC {_collidedNpcPed.Handle}. Incident at: {_incidentLocation}");
-                        UI.Notify("An NPC is calling the police!");
+                        GTA.UI.Screen.ShowNotification("An NPC is calling the police!");
                     }
-                    ResetNpcReactionState(); // NPC's role in initiating call is done
+                    ResetNpcReactionState(); 
                 }
                 break;
         }
@@ -238,8 +227,8 @@ public class NPCRoadRage : Script
     private void CheckPoliceArrival()
     {
         if (_policeVehicle == null || !_policeVehicle.Exists()) {
-             Log("Police vehicle does not exist. Aborting police response. This might be due to a spawn failure or it being removed by the game.");
-             CleanUpPolice(); // This resets PoliceCalled, _policeDispatched etc.
+             Log("Police vehicle does not exist. Aborting police response.");
+             CleanUpPolice(); 
              return;
         }
          if (_respondingPolicePeds.All(p => p == null || !p.Exists() || p.IsDead)) {
@@ -249,7 +238,9 @@ public class NPCRoadRage : Script
         }
 
         Ped driver = _policeVehicle.Driver;
-        if (driver != null && driver.Exists() && !driver.IsDead && driver.Position.DistanceTo(_incidentLocation) < PoliceArrivalDistanceThreshold && _policeVehicle.Speed < 1.0f)
+        if (driver != null && driver.Exists() && !driver.IsDead && 
+            driver.Position.DistanceTo(_incidentLocation) < PoliceArrivalDistanceThreshold && 
+            _policeVehicle.Speed < 1.0f)
         {
             Log("Police driver has arrived at the scene and vehicle has stopped.");
             _policeArrived = true;
@@ -263,7 +254,7 @@ public class NPCRoadRage : Script
         }
         else if (DateTime.Now > _stateTimer + _policeDispatchTimeoutDuration) 
         {
-            Log("Police dispatch timed out (_policeDispatchTimeoutDuration). They never arrived or got stuck. Cleaning up.");
+            Log("Police dispatch timed out. Cleaning up.");
             CleanUpPolice(); 
         }
     }
@@ -271,80 +262,78 @@ public class NPCRoadRage : Script
     private void ProcessPoliceInteraction()
     {
         Ped player = Game.Player.Character;
-        Ped leadOfficer = _respondingPolicePeds.FirstOrDefault(p => p.Exists() && p.IsAlive); 
+        Ped leadOfficer = _respondingPolicePeds.FirstOrDefault(p => p != null && p.Exists() && p.IsAlive); 
 
-        if (leadOfficer == null || !player.Exists()) { 
+        if (leadOfficer == null || player == null || !player.Exists()) { 
             Log("Lead officer or player is invalid. Ending police interaction.");
             EndPoliceInteraction(); return; 
         }
 
         if (_policeInteractionStage >= 0 && Game.Player.CanControlCharacter) {
             Log("Disabling player control for active police interaction.");
-            Game.Player.CanControlCharacter = false;
+            Game.Player.SetControlState(false, GTA.Control.All); 
         }
         
-        if (player.Exists()) player.Task.LookAt(leadOfficer);
-        if (leadOfficer.Exists() && !leadOfficer.IsRagdoll && leadOfficer.Tasks.CurrentTask?.Hash != Game.GenerateHash("TASK_GOTO_ENTITY")) { 
+        player.Task.LookAt(leadOfficer);
+        uint taskGotoEntityHash = (uint)Function.Call<int>(Hash.GET_HASH_KEY, "TASK_GOTO_ENTITY");
+        if (!leadOfficer.IsRagdoll && leadOfficer.Task.CurrentTask?.Hash != taskGotoEntityHash) { 
             leadOfficer.Task.LookAt(player);
         }
 
         switch (_policeInteractionStage)
         {
-            case -1: // Officers exiting vehicle and approaching
+            case -1: 
                 if (DateTime.Now > _stateTimer + _policeExitVehicleTimeoutDuration) {
                     Log("Timeout waiting for officers to exit vehicle. Attempting to force approach or abort.");
-                    bool anyOfficerStillInVehicle = false;
-                    foreach(Ped officer in _respondingPolicePeds.Where(o => o.Exists() && o.IsAlive)) {
-                        if(officer.IsInVehicle(_policeVehicle)) {
-                             officer.Tasks.LeaveVehicle(_policeVehicle, false); // Re-task, just in case
-                             anyOfficerStillInVehicle = true;
+                    bool anyOfficerStillInVehicleAfterTimeout = false;
+                    foreach(Ped officer in _respondingPolicePeds.Where(o => o != null && o.Exists() && o.IsAlive)) {
+                        if(_policeVehicle != null && _policeVehicle.Exists() && officer.IsInVehicle(_policeVehicle)) {
+                             officer.Task.LeaveVehicle(_policeVehicle, false); 
+                             anyOfficerStillInVehicleAfterTimeout = true;
                         }
                     }
-                    // If after re-tasking they are still stuck, or if they were already out but didn't approach:
-                    if (anyOfficerStillInVehicle && DateTime.Now > _stateTimer + _policeExitVehicleTimeoutDuration + TimeSpan.FromSeconds(5)) {
+                    if (anyOfficerStillInVehicleAfterTimeout && DateTime.Now > _stateTimer + _policeExitVehicleTimeoutDuration + TimeSpan.FromSeconds(5)) {
                         Log("Officers still stuck in vehicle after extended timeout. Aborting."); EndPoliceInteraction(); return;
                     }
-                    // If out, but didn't trigger approach logic yet
-                    if (!anyOfficerStillInVehicle) { _stateTimer = DateTime.Now; } // Reset timer to give them time to approach now
+                    if (!anyOfficerStillInVehicleAfterTimeout) { _stateTimer = DateTime.Now; } 
                 }
 
-                bool allOfficersOutOfVehicle = _respondingPolicePeds.All(p => !p.Exists() || !p.IsAlive || !p.IsInVehicle(_policeVehicle));
+                bool allOfficersOutOfVehicle = _respondingPolicePeds.All(p => p == null || !p.Exists() || !p.IsAlive || (_policeVehicle != null && _policeVehicle.Exists() && !p.IsInVehicle(_policeVehicle)) );
                 if (!allOfficersOutOfVehicle) return; 
 
                 bool allOfficersApproached = true;
-                foreach(Ped officer in _respondingPolicePeds.Where(o => o.Exists() && o.IsAlive)) {
-                    if (officer.Position.DistanceTo(player.Position) > OfficerApproachDistanceThreshold + 1.0f) { // Slightly larger threshold for check
-                        // Only re-task if not already approaching or if task seems stuck (e.g. no movement for a bit)
-                        if (officer.Tasks.CurrentTask?.Hash != Game.GenerateHash("TASK_GOTO_ENTITY") || officer.Velocity.LengthSquared() < 0.1f ) {
+                foreach(Ped officer in _respondingPolicePeds.Where(o => o != null && o.Exists() && o.IsAlive)) {
+                    if (officer.Position.DistanceTo(player.Position) > OfficerApproachDistanceThreshold + 1.0f) { 
+                        if (officer.Task.CurrentTask?.Hash != taskGotoEntityHash || officer.Velocity.LengthSquared() < 0.1f ) { 
                             Vector3 approachPoint = player.Position + player.ForwardVector * (OfficerApproachDistanceThreshold -1f) + player.RightVector * ((_respondingPolicePeds.IndexOf(officer) % 2 == 0) ? -1.0f : 1.0f);
-                            officer.Task.GoTo(approachPoint, false); 
+                            officer.Task.GoTo(approachPoint, false); // Corrected GoTo
                         }
                         allOfficersApproached = false;
-                    } else { // Arrived
-                         if(officer.IsWalking || officer.IsRunning) officer.Task.StandStill(-1); // Ensure they stop
+                    } else { 
+                         if(officer.IsWalking || officer.IsRunning) officer.Task.StandStill(-1); 
                     }
                 }
-                if (!allOfficersApproached && DateTime.Now < _stateTimer + _policeApproachTimeoutDuration) return; // Still waiting for approach
+                if (!allOfficersApproached && DateTime.Now < _stateTimer + _policeApproachTimeoutDuration) return; 
                 if (!allOfficersApproached && DateTime.Now >= _stateTimer + _policeApproachTimeoutDuration) {
                     Log("Timeout for officers to approach player. Aborting."); EndPoliceInteraction(); return;
                 }
                 
                 Log("All officers approached. Starting dialogue.");
-                if (!Game.Player.CanControlCharacter) Game.Player.CanControlCharacter = false; // Ensure it's disabled
+                if (Game.Player.CanControlCharacter) Game.Player.SetControlState(false, GTA.Control.All); 
                 _policeInteractionStage = 0;
                 _stateTimer = DateTime.Now; 
                 break;
             case 0: 
-                if (DateTime.Now < _stateTimer + TimeSpan.FromSeconds(1)) return; // Small settle pause
-                UI.Notify("Officer: We received a report of a vehicle collision here.", true);
+                if (DateTime.Now < _stateTimer + TimeSpan.FromSeconds(1)) return; 
+                GTA.UI.Screen.ShowNotification("Officer: We received a report of a vehicle collision here.");
                 Log("Interaction Stage 0: Officer statement 1.");
                 _policeInteractionStage++; _stateTimer = DateTime.Now; 
                 break;
             case 1: 
                 if (DateTime.Now < _stateTimer + _policeInteractionDialoguePauseDuration) return;
-                UI.Notify("Officer: What's your side of the story?", true);
+                GTA.UI.Screen.ShowNotification("Officer: What's your side of the story?");
                 Log("Interaction Stage 1: Officer asks player.");
-                _playerResponse = Game.GetUserInput(WindowTitle.EnterMessage60, "", 60); 
+                _playerResponse = Game.GetUserInput("Tell us what happened:", "", 60); 
                 if (string.IsNullOrEmpty(_playerResponse)) _playerResponse = "I have nothing to say."; 
                 Log($"Player responded: {_playerResponse}");
                 _policeInteractionStage++; _stateTimer = DateTime.Now;
@@ -354,18 +343,19 @@ public class NPCRoadRage : Script
                 if (_collidedNpcPed != null && _collidedNpcPed.Exists() && _collidedNpcPed.IsAlive && _incidentLocation.DistanceTo(_collidedNpcPed.Position) < 25f) 
                 {
                     if (leadOfficer != null && leadOfficer.Exists()) _collidedNpcPed.Task.LookAt(leadOfficer);
-                    else if(player.Exists()) _collidedNpcPed.Task.LookAt(player);
+                    else if(player != null && player.Exists()) _collidedNpcPed.Task.LookAt(player);
                     string npcStatement = $"NPC ({_collidedNpcPed.Handle}): They crashed right into me! It was their fault!";
-                    UI.Notify(npcStatement, true); Log($"Interaction Stage 2: NPC statement: {npcStatement}");
+                    GTA.UI.Screen.ShowNotification(npcStatement); 
+                    Log($"Interaction Stage 2: NPC statement: {npcStatement}");
                 } else {
                     Log("Interaction Stage 2: Original NPC not available or too far for statement.");
-                    UI.Notify("Officer: The other party isn't present to give a statement.", true);
+                    GTA.UI.Screen.ShowNotification("Officer: The other party isn't present to give a statement.");
                 }
                 _policeInteractionStage++; _stateTimer = DateTime.Now;
                 break;
             case 3: 
                 if (DateTime.Now < _stateTimer + _policeInteractionDialoguePauseDuration) return;
-                UI.Notify("Officer: Alright, let me assess the situation...", true);
+                GTA.UI.Screen.ShowNotification("Officer: Alright, let me assess the situation...");
                 Log("Interaction Stage 3: Officer assessing.");
                 _policeInteractionStage++; _stateTimer = DateTime.Now; 
                 break;
@@ -380,7 +370,7 @@ public class NPCRoadRage : Script
     }
     
     private void DecidePoliceAction() {
-        Log("Deciding police action based on player response and NPC statement.");
+        Log("Deciding police action...");
         bool playerCooperative = true;
         bool admitFault = false;
         string lowerPlayerResponse = _playerResponse.ToLower();
@@ -398,8 +388,9 @@ public class NPCRoadRage : Script
         }
 
         bool npcAccusatory = (_collidedNpcPed != null && _collidedNpcPed.Exists() && _collidedNpcPed.IsAlive);
+        Ped player = Game.Player.Character;
 
-        if (Game.Player.WantedLevel > 0) {
+        if (player != null && player.Exists() && Game.Player.Wanted.Level > 0) { 
              _currentPoliceDecision = PoliceDecision.ArrestPlayer; Log("Decision: Arrest Player (already wanted).");
         } else if (admitFault) {
             _currentPoliceDecision = PoliceDecision.ArrestPlayer; Log("Decision: Arrest Player (admitted fault).");
@@ -411,14 +402,16 @@ public class NPCRoadRage : Script
         } else {
             _currentPoliceDecision = PoliceDecision.LetPlayerGo; Log("Decision: Let Player Go (cooperative).");
         }
-        _stateTimer = DateTime.Now; // Reset timer for outcome processing
+        _stateTimer = DateTime.Now; 
     }
 
     private void ProcessPoliceDecisionOutcome()
     {
         Ped player = Game.Player.Character;
-        Ped arrestingOfficer = _respondingPolicePeds.FirstOrDefault(p => p.Exists() && p.IsAlive);
+        Ped arrestingOfficer = _respondingPolicePeds.FirstOrDefault(p => p != null && p.Exists() && p.IsAlive);
         
+        if (player == null || !player.Exists()) { Log("Player is invalid, cannot process decision outcome."); EndPoliceInteraction(); return; }
+
         if (arrestingOfficer == null && _currentPoliceDecision == PoliceDecision.ArrestPlayer) {
             Log("No officer available to perform arrest. Letting player go by default.");
             _currentPoliceDecision = PoliceDecision.LetPlayerGo; 
@@ -428,66 +421,79 @@ public class NPCRoadRage : Script
         switch (_currentPoliceDecision)
         {
             case PoliceDecision.ArrestPlayer:
-                if (!player.IsBeingArrested && !Function.Call<bool>(Hash.IS_PED_CUFFED, player.Handle)) {
-                    UI.Notify("Officer: You're coming with us!", true);
-                    if (arrestingOfficer != null && player.Exists()) {
+                bool alreadyArrested = player.IsCuffed || Function.Call<bool>(Hash.IS_PED_BEING_ARRESTED, player.Handle);
+                if (!alreadyArrested) {
+                    GTA.UI.Screen.ShowNotification("Officer: You're coming with us!");
+                    if (arrestingOfficer != null && arrestingOfficer.Exists()) 
+                    {
                         Log($"Officer {arrestingOfficer.Handle} is arresting player {player.Handle}.");
-                        arrestingOfficer.Tasks.Arrest(player);
+                        arrestingOfficer.Task.Arrest(player);
                     }
                 }
                 
-                if (DateTime.Now > _stateTimer + _policeArrestSequenceDuration || Function.Call<bool>(Hash.IS_PED_CUFFED, player.Handle)) {
-                    UI.ShowSubtitle("~r~BUSTED!", 5000);
+                if (DateTime.Now > _stateTimer + _policeArrestSequenceDuration || player.IsCuffed || Function.Call<bool>(Hash.IS_PED_BEING_ARRESTED, player.Handle)) {
+                    GTA.UI.Screen.ShowSubtitle("~r~BUSTED!", 5000);
                     Log("Player busted. Ending interaction.");
-                    Game.Player.WantedLevel = Math.Max(Game.Player.WantedLevel, 1); 
+                    int currentWantedLevel = Game.Player.Wanted.Level; 
+                    Game.Player.Wanted.SetWantedLevel(Math.Max(currentWantedLevel, 1), false); 
+                    Game.Player.Wanted.ApplyWantedLevelChangeNow(false); 
                     EndPoliceInteraction(true); 
                 }
                 break;
 
             case PoliceDecision.LetPlayerGo:
-                 // Show message once using a flag or by checking current stage if we had one for "saying goodbye"
-                if (DateTime.Now < _stateTimer + TimeSpan.FromSeconds(0.5)) { // Display for a short time
-                     UI.Notify("Officer: Alright, be more careful next time. You're free to go.", true);
+                if (DateTime.Now < _stateTimer + TimeSpan.FromSeconds(0.5)) { 
+                     GTA.UI.Screen.ShowNotification("Officer: Alright, be more careful next time. You're free to go.");
                      Log("Police letting player go.");
                 }
 
-                if (DateTime.Now > _stateTimer + _policeInteractionDialoguePauseDuration) // Wait for message to be read
+                if (DateTime.Now > _stateTimer + _policeInteractionDialoguePauseDuration)
                 {
                     if (_policeVehicle != null && _policeVehicle.Exists())
                     {
-                        bool allBoardedOrBoarding = true;
+                        bool allAboardOrDriving = true;
                         Ped driver = _policeVehicle.Driver;
+                        uint taskEnterVehicleHash = (uint)Function.Call<int>(Hash.GET_HASH_KEY, "TASK_ENTER_VEHICLE");
+                        uint taskDriveWanderHash = (uint)Function.Call<int>(Hash.GET_HASH_KEY, "TASK_VEHICLE_DRIVE_WANDER");
 
-                        foreach (Ped officer in _respondingPolicePeds.Where(o => o.Exists() && o.IsAlive)) {
+
+                        foreach (Ped officer in _respondingPolicePeds.Where(o => o != null && o.Exists() && o.IsAlive)) {
                             if (!officer.IsInVehicle(_policeVehicle)) {
-                                if(officer.Tasks.CurrentTask?.Hash != Game.GenerateHash("TASK_ENTER_VEHICLE")) {
+                                if(officer.Task.CurrentTask?.Hash != taskEnterVehicleHash) { 
                                      officer.Task.EnterVehicle(_policeVehicle, VehicleSeat.Any);
                                 }
-                                allBoardedOrBoarding = false;
+                                allAboardOrDriving = false;
                             }
                         }
-                        // If driver is in but not driving yet, or if others are still boarding
-                        if (driver != null && driver.Exists() && driver.IsInVehicle(_policeVehicle) && _policeVehicle.Speed < 1f && 
-                            driver.Tasks.CurrentTask?.Hash != Game.GenerateHash("TASK_VEHICLE_DRIVE_WANDER")) {
-                            allBoardedOrBoarding = false; // Still waiting for driver to start moving
+                        
+                        if (driver != null && driver.Exists() && driver.IsInVehicle(_policeVehicle)) {
+                            if (_policeVehicle.Speed < 1f && driver.Task.CurrentTask?.Hash != taskDriveWanderHash) { 
+                                allAboardOrDriving = false; 
+                            } else if (_policeVehicle.Speed >=1f) {
+                                // allAboardOrDriving stays true
+                            }
+                        } else { 
+                            allAboardOrDriving = false;
                         }
 
-
-                        if (allBoardedOrBoarding || DateTime.Now > _stateTimer + _policeInteractionDialoguePauseDuration + _policeDepartureBoardingTimeoutDuration) 
+                        if (allAboardOrDriving || DateTime.Now > _stateTimer + _policeInteractionDialoguePauseDuration + _policeDepartureBoardingTimeoutDuration) 
                         {
-                             driver = _policeVehicle.Driver; // Re-check driver
+                             driver = _policeVehicle.Driver; 
                              if(driver != null && driver.Exists() && _respondingPolicePeds.Contains(driver) && driver.IsInVehicle(_policeVehicle)) {
-                                if (_policeVehicle.Speed < 1f && driver.Tasks.CurrentTask?.Hash != Game.GenerateHash("TASK_VEHICLE_DRIVE_WANDER")) { 
+                                if (_policeVehicle.Speed < 1f && driver.Task.CurrentTask?.Hash != taskDriveWanderHash) { 
                                     Vector3 awayPos = _policeVehicle.Position + _policeVehicle.ForwardVector * 300f; 
-                                    driver.Task.DriveTo(_policeVehicle, World.GetNextPositionOnStreet(awayPos), 5f, 20f, DrivingStyle.Normal);
+                                    driver.Task.DriveTo(_policeVehicle, World.GetNextPositionOnStreet(awayPos), 5f, VehicleDrivingFlags.FollowTraffic, PolicePatrolSpeed); 
                                     Log("Police driver tasked to leave.");
                                 }
-                             } else if (driver == null) { 
-                                Log("No police driver to leave. Forcing cleanup."); EndPoliceInteraction(false); return;
+                             } else if (driver == null && _respondingPolicePeds.Any(p => p != null && p.Exists())) { 
+                                Log("No police driver to leave, but other officers present. Forcing cleanup."); 
+                                EndPoliceInteraction(false); return;
+                             } else if (!_respondingPolicePeds.Any(p => p != null && p.Exists())) { 
+                                Log("No officers present. Forcing cleanup."); EndPoliceInteraction(false); return;
                              }
                             
                             if (DateTime.Now > _stateTimer + _policeInteractionDialoguePauseDuration + _policeDepartureBoardingTimeoutDuration + _policeDepartureDriveAwayDuration || 
-                                (_policeVehicle != null && _policeVehicle.Position.DistanceTo(player.Position) > 150f) ) 
+                                (_policeVehicle != null && _policeVehicle.Exists() && _policeVehicle.Position.DistanceTo(player.Position) > 150f) ) 
                             {
                                 Log("Police presumed to have left. Ending interaction.");
                                 EndPoliceInteraction(false);
@@ -504,7 +510,7 @@ public class NPCRoadRage : Script
     }
     
     private void ResetNpcReactionState() {
-        Log($"Resetting NPC reaction state for Handle: {_collidedNpcPed?.Handle.ToString() ?? "N/A"}.");
+        Log($"Resetting NPC reaction state for Handle: {(_collidedNpcPed != null && _collidedNpcPed.Exists() ? _collidedNpcPed.Handle.ToString() : "N/A")}.");
         if (_collidedNpcPed != null && _collidedNpcPed.Exists()) { 
             _collidedNpcPed.MarkAsNoLongerNeeded(); 
         }
@@ -517,7 +523,7 @@ public class NPCRoadRage : Script
         _currentReaction = NpcReactionType.None;
     }
 
-    public void CleanUpPolice(bool immediate = false) { // Added immediate flag for quicker cleanup if needed
+    public void CleanUpPolice(bool immediate = false) { 
         Log("Cleaning up police units.");
         if (_policeVehicle != null && _policeVehicle.Exists()) {
             _policeVehicle.MarkAsNoLongerNeeded();
@@ -533,7 +539,7 @@ public class NPCRoadRage : Script
         _respondingPolicePeds.Clear();
         _policeDispatched = false; 
         _policeArrived = false;
-        PoliceCalled = false; // Critical: Reset this so new incidents can start
+        PoliceCalled = false; 
         _incidentLocation = Vector3.Zero;
         Log("Police cleanup complete.");
     }
@@ -542,7 +548,7 @@ public class NPCRoadRage : Script
     {
         Log($"Ending police interaction. Player arrested: {playerArrested}, Player fled: {playerFled}");
         Ped player = Game.Player.Character;
-        if(player.Exists() && !Game.Player.CanControlCharacter) Game.Player.CanControlCharacter = true;
+        if(player != null && player.Exists() && !Game.Player.CanControlCharacter) Game.Player.SetControlState(true, GTA.Control.All); 
         
         _policeInteractionActive = false;
         _makingPoliceDecision = false;
@@ -550,24 +556,22 @@ public class NPCRoadRage : Script
         _policeInteractionStage = 0;
         _playerResponse = string.Empty;
         
-        // If player arrested, game's wanted system takes over.
-        // If player fled, police might search or give up. For script, we clean up.
-        // If let go, police leave and then we clean up.
-        // The key is that CleanUpPolice resets PoliceCalled, allowing a new incident.
-        
-        // For simplicity, always clean up our entities.
-        // If player arrested, they are usually teleported or screen fades, our entities might look odd if left too long.
-        CleanUpPolice(playerArrested || playerFled); // Pass true for immediate if arrested or fled
+        CleanUpPolice(playerArrested || playerFled); 
     }
 
     private void FullResetOfScriptStates() {
         Log("Performing full reset of script states.");
         ResetNpcReactionState();
-        EndPoliceInteraction(false, false); // This calls CleanUpPolice
+        EndPoliceInteraction(false, false); 
         _npcCollisionCooldowns.Clear(); 
-        // Reset any other global script flags not covered by above to ensure a clean start
         _incidentLocation = Vector3.Zero;
         _playerResponse = string.Empty;
+        _npcReacting = false;
+        _policeDispatched = false;
+        _policeArrived = false;
+        _policeInteractionActive = false;
+        _makingPoliceDecision = false;
+        PoliceCalled = false; 
         Log("Full reset complete.");
     }
    
@@ -576,15 +580,15 @@ public class NPCRoadRage : Script
         Log($"Dispatching police to: {incidentLocation}");
         _policeDispatched = true;
         _policeArrived = false; 
-        _stateTimer = DateTime.Now; // Timer for dispatch timeout
+        _stateTimer = DateTime.Now; 
 
-        Vector3 spawnPoint = World.GetNextPositionOnStreet(incidentLocation + (Game.Player.Character.ForwardVector * -100f), true); // Spawn further back
-        if (spawnPoint == Vector3.Zero || spawnPoint.DistanceTo(incidentLocation) < 50f) { // Fallback if no good street point or too close
-            spawnPoint = incidentLocation + new Vector3(80, 80, 0); // Rough offset if street search fails
+        Vector3 spawnPoint = World.GetNextPositionOnStreet(incidentLocation + (Game.Player.Character.ForwardVector * -100f), true); 
+        if (spawnPoint == Vector3.Zero || spawnPoint.DistanceTo(incidentLocation) < 50f) { 
+            spawnPoint = incidentLocation + new Vector3(80, 80, 0); 
             Log("Could not find suitable street position for police spawn, using offset.");
         }
 
-        _policeVehicle = World.CreateVehicle(_policeVehicleModel, spawnPoint, Utility.GetHeadingFromVector(incidentLocation - spawnPoint)); // Face towards incident
+        _policeVehicle = World.CreateVehicle(_policeVehicleModel, spawnPoint, Utility.GetHeadingFromVector(incidentLocation - spawnPoint)); 
         if (_policeVehicle == null || !_policeVehicle.Exists())
         {
             Log("Failed to spawn police vehicle.");
@@ -596,7 +600,6 @@ public class NPCRoadRage : Script
         _respondingPolicePeds.Clear(); 
         for (int i = 0; i < NumberOfPoliceOfficers; i++)
         {
-            // Spawn slightly offset from each other to prevent collision
             Vector3 officerSpawnPos = _policeVehicle.Position + _policeVehicle.RightVector * (i * 1.5f) - _policeVehicle.ForwardVector * (i * 0.5f);
             Ped officer = World.CreatePed(_policePedModel, officerSpawnPos);
             if (officer != null && officer.Exists())
@@ -611,34 +614,37 @@ public class NPCRoadRage : Script
         }
 
         Ped driver = _policeVehicle.Driver;
-        if (driver != null && driver.Exists() && _respondingPolicePeds.Contains(driver))
+        if (driver != null && driver.Exists() && _respondingPolicePeds.Contains(driver) && _policeVehicle != null && _policeVehicle.Exists()) 
         {
             Log($"Police driver {driver.Handle} is in vehicle. Tasking to drive to incident: {incidentLocation}");
-            driver.Task.DriveTo(_policeVehicle, incidentLocation, PoliceArrivalDistanceThreshold / 2f, 30.0f, DrivingStyle.Rushed); // Speed in m/s, make it high
+            driver.Task.DriveTo(_policeVehicle, incidentLocation, PoliceArrivalDistanceThreshold / 2f, VehicleDrivingFlags.Emergency, PoliceDriveSpeed); 
             _policeVehicle.IsSirenActive = true; 
         } else {
             Log("Police driver not found or not set in vehicle correctly. Cannot dispatch.");
-            CleanUpPolice(); // Clean up partially spawned units
+            CleanUpPolice(); 
             return;
         }
-        UI.Notify("Police have been dispatched to your location!");
+        GTA.UI.Screen.ShowNotification("Police have been dispatched to your location!");
     }
 
     private void Log(string message) {
         try { File.AppendAllText("NPCRoadRage.log", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") + " : " + message + Environment.NewLine); }
-        catch (Exception ex) { UI.Notify("Log Error: " + ex.Message, true); }
+        catch (Exception ex) { GTA.UI.Screen.ShowNotification("Log Error: " + ex.Message); }
     }
 
     private void OnKeyDown(object sender, KeyEventArgs e) {
+        Ped player = Game.Player.Character;
+        if (player == null || !player.Exists()) return; 
+
         if (e.KeyCode == Keys.L) {
             Log("Test Key L: Simulating police call for interaction test.");
-            if(Game.Player.Character.IsInVehicle()) { Game.Player.Character.Task.LeaveVehicle(); Script.Wait(1500); } // Ensure player is out
+            if(player.IsInVehicle()) { player.Task.LeaveVehicle(); Script.Wait(1500); } 
             
-            FullResetOfScriptStates(); // Clears everything including old police incident
+            FullResetOfScriptStates(); 
 
-            _incidentLocation = Game.Player.Character.Position + Game.Player.Character.ForwardVector * 10f;
-            PoliceCalled = true; // This will trigger dispatch in OnTick
-            _stateTimer = DateTime.Now; // Set timer for the initial phase (dispatch timeout)
+            _incidentLocation = player.Position + player.ForwardVector * 10f;
+            PoliceCalled = true; 
+            _stateTimer = DateTime.Now; 
             Log("Test key: PoliceCalled=true. Dispatch should occur on next tick.");
         }
         if (e.KeyCode == Keys.J) {


### PR DESCRIPTION
…ript

This commit resolves multiple build errors in the NPCRoadRage.cs script by updating API usage to be compatible with ScriptHookVDotNet V3.

Key corrections include:
- Addressed non-nullable field warnings (CS8618) by making relevant fields nullable and ensuring null checks.
- Fixed UI class usage (CS0103): Replaced `UI.Notify`/`ShowSubtitle` with `GTA.UI.Screen.ShowNotification`/`ShowSubtitle`. Corrected `Game.GetUserInput` title.
- Corrected Ped task invocation (CS1061): Changed `Ped.Tasks` to `Ped.Task`. Updated `FightAgainst` to `Combat`. Implemented native calls/property checks for `IsGettingOutOfVehicle` and `IsBeingArrested`.
- Addressed other obsolete API usage (CS0618): Removed `Game.IsLoading`. Replaced `Game.GenerateHash` with `Function.Call` for `GET_HASH_KEY`. Updated `Player.CanControlCharacter` to `SetControlState`. Updated `Player.WantedLevel` to use `Game.Player.Wanted` methods. Updated `DriveTo` tasks to use `VehicleDrivingFlags`.
- Corrected method argument mismatches (CS1503): Updated `World.GetNearbyVehicles` to use LINQ for filtering. Ensured `Ped.Task.GoTo` calls use correct overloads.
- Performed a final review to ensure changes are consistent and correctly integrated.
- General code refinements for robustness, including better state reset logic and use of configuration constants.