### PR TITLE
Fix obsolete property warnings

### DIFF
--- a/UrbanLife/RoadEventManager.cs
+++ b/UrbanLife/RoadEventManager.cs
@@ -1057,7 +1057,6 @@ namespace REALIS.UrbanLife
                                         driver.BlockPermanentEvents = true;
                                         driver.CanBeDraggedOutOfVehicle = false;
                                         driver.KnockOffVehicleType = KnockOffVehicleType.Never;
-                                        driver.CanBeKnockedOffBike = false;
                                         driver.CanBeTargetted = false; // Éviter interactions externes
                                         
                                         // NOUVEAU: Appliquer plusieurs fois pour s'assurer que ça tient
@@ -1222,7 +1221,6 @@ namespace REALIS.UrbanLife
                                 driver.BlockPermanentEvents = true;
                                 driver.CanBeDraggedOutOfVehicle = false;
                                 driver.KnockOffVehicleType = KnockOffVehicleType.Never;
-                                driver.CanBeKnockedOffBike = false;
                                 driver.CanBeTargetted = false;
                                 
                                 // NOUVEAU: Si le PNJ sort pendant la période de grâce, le remettre immédiatement
@@ -1331,7 +1329,6 @@ namespace REALIS.UrbanLife
                                 driver.BlockPermanentEvents = true;
                                 driver.CanBeDraggedOutOfVehicle = false;
                                 driver.KnockOffVehicleType = KnockOffVehicleType.Never;
-                                driver.CanBeKnockedOffBike = false;
                                 driver.CanBeTargetted = false;
                             }
                             
@@ -1433,7 +1430,6 @@ namespace REALIS.UrbanLife
                                     driver.BlockPermanentEvents = true;
                                     driver.CanBeDraggedOutOfVehicle = false;
                                     driver.KnockOffVehicleType = KnockOffVehicleType.Never;
-                                    driver.CanBeKnockedOffBike = false;
                                     driver.CanBeTargetted = false;
                                     
                                     // NOUVEAU: Double application des protections avec délai
@@ -2835,7 +2831,6 @@ namespace REALIS.UrbanLife
                                         driver.BlockPermanentEvents = true;
                                         driver.CanBeDraggedOutOfVehicle = false;
                                         driver.KnockOffVehicleType = KnockOffVehicleType.Never;
-                                        driver.CanBeKnockedOffBike = false;
                                         driver.CanBeTargetted = false;
                                         
                                         GTA.UI.Notification.PostTicker("~r~CORRECTION: Le passager remonte automatiquement!", false);


### PR DESCRIPTION
## Summary
- remove deprecated `CanBeKnockedOffBike` property usage in `RoadEventManager`

## Testing
- `dotnet build REALIS.csproj -v minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f710c4478832a88fc954d166e9e92