### PR TITLE
Fix obsolete property warnings

### DIFF
--- a/UrbanLife/RoadEventManager.cs
+++ b/UrbanLife/RoadEventManager.cs
@@ -1057,7 +1057,6 @@ namespace REALIS.UrbanLife
                                         driver.BlockPermanentEvents = true;
                                         driver.CanBeDraggedOutOfVehicle = false;
                                         driver.KnockOffVehicleType = KnockOffVehicleType.Never;
-                                        driver.CanBeKnockedOffBike = false;
                                         driver.CanBeTargetted = false; // Éviter interactions externes
                                         
                                         // NOUVEAU: Appliquer plusieurs fois pour s'assurer que ça tient
@@ -1222,7 +1221,6 @@ namespace REALIS.UrbanLife
                                 driver.BlockPermanentEvents = true;
                                 driver.CanBeDraggedOutOfVehicle = false;
                                 driver.KnockOffVehicleType = KnockOffVehicleType.Never;
-                                driver.CanBeKnockedOffBike = false;
                                 driver.CanBeTargetted = false;
                                 
                                 // NOUVEAU: Si le PNJ sort pendant la période de grâce, le remettre immédiatement
@@ -1331,7 +1329,6 @@ namespace REALIS.UrbanLife
                                 driver.BlockPermanentEvents = true;
                                 driver.CanBeDraggedOutOfVehicle = false;
                                 driver.KnockOffVehicleType = KnockOffVehicleType.Never;
-                                driver.CanBeKnockedOffBike = false;
                                 driver.CanBeTargetted = false;
                             }
                             
@@ -1433,7 +1430,6 @@ namespace REALIS.UrbanLife
                                     driver.BlockPermanentEvents = true;
                                     driver.CanBeDraggedOutOfVehicle = false;
                                     driver.KnockOffVehicleType = KnockOffVehicleType.Never;
-                                    driver.CanBeKnockedOffBike = false;
                                     driver.CanBeTargetted = false;
                                     
                                     // NOUVEAU: Double application des protections avec délai
@@ -2835,7 +2831,6 @@ namespace REALIS.UrbanLife
                                         driver.BlockPermanentEvents = true;
                                         driver.CanBeDraggedOutOfVehicle = false;
                                         driver.KnockOffVehicleType = KnockOffVehicleType.Never;
-                                        driver.CanBeKnockedOffBike = false;
                                         driver.CanBeTargetted = false;
                                         
                                         GTA.UI.Notification.PostTicker("~r~CORRECTION: Le passager remonte automatiquement!", false);


### PR DESCRIPTION
## Summary
- revert unintended build artifact changes
- remove deprecated `CanBeKnockedOffBike` usages in `RoadEventManager`

## Testing
- `dotnet add package Newtonsoft.Json --version 13.0.3`
- `dotnet clean`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_683f710c4478832a88fc954d166e9e92
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove deprecated `CanBeKnockedOffBike` property from `RoadEventManager.cs` and revert unintended build artifact changes.
> 
>   - **Behavior**:
>     - Remove deprecated `CanBeKnockedOffBike` property from `UpdateBrokenDownVehicleBehavior()` in `RoadEventManager.cs`.
>   - **Misc**:
>     - Revert unintended build artifact changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JeremGamingYT%2FRPAP&utm_source=github&utm_medium=referral)<sup> for b5f301ce02def44bd4eb545176f82fcd86f9a7ba. You can [customize](https://app.ellipsis.dev/JeremGamingYT/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->