### PR TITLE
Improve NPC Intelligence reaction to gunfire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # NPCRoadRage Script - Changelog
 
+## Version 1.27.2 - NPCIntelligence Build Cleanup (2025-06-04)
+
+### ✅ Compilation
+- Suppression de la variable inutile `playerShooting` qui provoquait une erreur de compilation
+
+## Version 1.27.3 - NPCIntelligence réagit aux coups de feu (2025-06-04)
+
+### ➕ Améliorations
+- Les PNJ fuient également lorsqu'ils entendent des tirs à proximité.
+
+## Version 1.27.1 - NPCIntelligence Build Fix (2025-06-03)
+
+### 🛠️ Correction de build
+- Utilisation correcte de `Game.Player.Wanted` pour ajuster le niveau de recherche
+- Suppression d'un appel invalide `IsFiringWeapon` sur `Ped`
+
+## Version 1.27 - Enhanced NPC Intelligence (2025-06-02)
+
+### 🤖 PNJ plus intelligents hors traffic
+- Nouveau dossier `NPCIntelligence` avec gestionnaire dédié.
+- Les PNJ fuient ou appellent la police lorsqu'ils sont menacés.
+
 
 ## Version 1.26 - Intelligent Traffic AI (2025-06-01)
 

--- a/NPCIntelligence/NPCIntelligenceManager.cs
+++ b/NPCIntelligence/NPCIntelligenceManager.cs
@@ -1,0 +1,115 @@
+using GTA;
+using GTA.Native;
+using System;
+using System.Collections.Generic;
+
+namespace REALIS.NPCIntelligence
+{
+    /// <summary>
+    /// Simple intelligence layer for ambient NPCs.
+    /// NPCs react to threats near the player and may call the police.
+    /// </summary>
+    public class NPCIntelligenceManager : Script
+    {
+        private readonly Dictionary<int, NPCStatusInfo> _statuses = new();
+
+        private const float CheckRadius = 40f;
+        private const float ThreatRadius = 12f;
+
+        public NPCIntelligenceManager()
+        {
+            Tick += OnTick;
+            Interval = 0;
+        }
+
+        private void OnTick(object sender, EventArgs e)
+        {
+            Ped player = Game.Player.Character;
+            if (player == null || !player.Exists() || player.IsDead)
+                return;
+
+            bool playerShooting = Function.Call<bool>(Hash.IS_PED_SHOOTING, player);
+
+            foreach (Ped ped in World.GetNearbyPeds(player, CheckRadius))
+            {
+                if (ped == null || !ped.Exists() || ped.IsDead || ped == player)
+                    continue;
+
+                if (!_statuses.TryGetValue(ped.Handle, out var info))
+                {
+                    info = new NPCStatusInfo(ped);
+                    _statuses[ped.Handle] = info;
+                }
+
+                UpdatePed(ped, player, info, playerShooting);
+            }
+
+            CleanupStatuses();
+        }
+
+        private void UpdatePed(Ped ped, Ped player, NPCStatusInfo info, bool playerShooting)
+        {
+            bool beingAimedAt = Function.Call<bool>(Hash.IS_PLAYER_FREE_AIMING_AT_ENTITY, Game.Player, ped);
+            bool closeThreat = player.Position.DistanceTo(ped.Position) < ThreatRadius;
+
+            if ((beingAimedAt && closeThreat) || (playerShooting && closeThreat) || ped.HasBeenDamagedBy(player))
+            {
+                if (!info.Reacted)
+                {
+                    ped.Task.ReactAndFlee(player);
+                    info.Reacted = true;
+                    info.LastThreatTime = Game.GameTime;
+                }
+            }
+            else if (info.Reacted && Game.GameTime - info.LastThreatTime > 5000)
+            {
+                info.Reacted = false;
+            }
+
+            if (info.Reacted && !info.CalledPolice && Game.GameTime - info.LastThreatTime > 2000)
+            {
+                CallPolice(ped);
+                info.CalledPolice = true;
+            }
+        }
+
+        private void CallPolice(Ped caller)
+        {
+            GTA.Wanted wanted = Game.Player.Wanted;
+            if (wanted.WantedLevel < 2)
+            {
+                wanted.SetWantedLevel(2, false);
+                wanted.ApplyWantedLevelChangeNow(false);
+            }
+            Function.Call(Hash.PLAY_SOUND_FRONTEND, -1, "Cell_Call_To", "Phone_SoundSet", false);
+        }
+
+        private void CleanupStatuses()
+        {
+            var invalid = new List<int>();
+            foreach (var pair in _statuses)
+            {
+                if (!pair.Value.Ped.Exists())
+                    invalid.Add(pair.Key);
+            }
+            foreach (var key in invalid)
+                _statuses.Remove(key);
+        }
+    }
+
+    internal class NPCStatusInfo
+    {
+        public Ped Ped { get; }
+        public bool Reacted { get; set; }
+        public bool CalledPolice { get; set; }
+        public int LastThreatTime { get; set; }
+
+        public NPCStatusInfo(Ped ped)
+        {
+            Ped = ped;
+            Reacted = false;
+            CalledPolice = false;
+            LastThreatTime = 0;
+        }
+    }
+}

--- a/NPCIntelligence/README.md
+++ b/NPCIntelligence/README.md
@@ -1,0 +1,5 @@
+# NPCIntelligence
+
+Ce dossier contient un gestionnaire d'intelligence basique pour les PNJ hors circulation.
+Les passants réagissent si le joueur les menace ou leur tire dessus et peuvent appeler la police.
+Ils tiennent aussi compte des tirs à proximité pour fuir plus rapidement.


### PR DESCRIPTION
## Summary
- make NPCs react to nearby gunfire in NPCIntelligenceManager
- document updated behaviour in NPCIntelligence README
- log enhancement in changelog

## Testing
- `dotnet build REALIS.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8167a75c832ab6a17fc73f75c3b4
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> NPCs now react to nearby gunfire by fleeing and possibly calling the police, with updated documentation and changelog.
> 
>   - **Behavior**:
>     - NPCs now react to nearby gunfire in `NPCIntelligenceManager.cs` by fleeing and potentially calling the police.
>     - NPCs consider proximity of gunfire to decide on fleeing.
>   - **Documentation**:
>     - Updated `README.md` to reflect new NPC behavior regarding gunfire.
>   - **Changelog**:
>     - Added entry in `CHANGELOG.md` for version 1.27.3 detailing NPC reactions to gunfire.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JeremGamingYT%2FRPAP&utm_source=github&utm_medium=referral)<sup> for 33c595e0de49fe4ae32fb0a2a3e7f17014f14e4a. You can [customize](https://app.ellipsis.dev/JeremGamingYT/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->