### PR TITLE
Fix vehicle crash by disabling passenger monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+Ce dépôt contient divers scripts pour GTA V.
+
+### Changement récent
+
+* La touche **R** dans `UrbanLife` est maintenant désactivée afin d'éviter les crashs potentiels.
+
+
+* Le suivi automatique du passager dans `UrbanLife` est désactivé pour eviter un crash en conduisant.

--- a/UrbanLife/RoadEventManager.cs
+++ b/UrbanLife/RoadEventManager.cs
@@ -62,8 +62,10 @@ namespace REALIS.UrbanLife
                 lastInteractionCheck = DateTime.Now;
             }
             
-            // NOUVEAU: Surveiller la stabilité des passagers
-            MonitorPassengerStability();
+            // La surveillance automatique des passagers provoque parfois des
+            // plantages lorsqu'on conduit. Elle est désactivée pour l'instant
+            // pour éviter ces crashs.
+            //MonitorPassengerStability();
             
             // Mettre à jour les événements actifs
             UpdateActiveRoadEvents();

--- a/UrbanLife/UrbanLifeMain.cs
+++ b/UrbanLife/UrbanLifeMain.cs
@@ -146,11 +146,6 @@ namespace REALIS.UrbanLife
                     blipManager.ClearAllBlips();
                     GTA.UI.Notification.PostTicker("~g~Tous les blips d'événements ont été effacés!", false);
                 }
-                else if (e.KeyCode == System.Windows.Forms.Keys.R)
-                {
-                    // SUPPRIMÉ - causait des conflits
-                    GTA.UI.Notification.PostTicker("~r~Touche R désactivée pour éviter les conflits", false);
-                }
                 else if (e.KeyCode == System.Windows.Forms.Keys.F7)
                 {
                     // CORRECTION F7: Protection contre les crashes à répétition


### PR DESCRIPTION
## Summary
- comment out `MonitorPassengerStability` in `RoadEventManager` to avoid vehicle crash
- note the disabled passenger monitoring in README

## Testing
- `dotnet build REALIS.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9e71b9d0832aa51913a128134a19