### PR TITLE
Disable NPCRoadRage integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Ce dépôt contient divers scripts pour GTA V.
 
 
 * Le suivi automatique du passager dans `UrbanLife` est désactivé pour eviter un crash en conduisant.
+* L'intégration `NPCRoadRage` est maintenant désactivée afin d'éviter les plantages quand on croise d'autres véhicules.

--- a/UrbanLife/UrbanLifeMain.cs
+++ b/UrbanLife/UrbanLifeMain.cs
@@ -381,8 +381,9 @@ namespace REALIS.UrbanLife
             interventionSystem.Update();
             
             // Vérifier les événements NPCRoadRage
-            NPCRoadRageIntegration.CheckForRoadRageEvents();
-            NPCRoadRageIntegration.DetectCollisionEvents();
+            // Désactivé car la détection peut provoquer un crash
+            //NPCRoadRageIntegration.CheckForRoadRageEvents();
+            //NPCRoadRageIntegration.DetectCollisionEvents();
             
             // Vérifier les événements spéciaux (garder pour compatibilité mais réduire la fréquence)
             CheckForSpecialEvents();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable `NPCRoadRage` integration in `UrbanLifeMain.cs` to prevent crashes, and update `README.md` accordingly.
> 
>   - **Behavior**:
>     - Disable `NPCRoadRageIntegration.CheckForRoadRageEvents()` and `NPCRoadRageIntegration.DetectCollisionEvents()` in `UrbanLifeMain.cs` to prevent crashes.
>   - **Documentation**:
>     - Update `README.md` to note the disabling of `NPCRoadRage` integration to avoid crashes when encountering other vehicles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JeremGamingYT%2FRPAP&utm_source=github&utm_medium=referral)<sup> for d6c2d6fda7242e53bc57834badd6d26dc1af02ee. You can [customize](https://app.ellipsis.dev/JeremGamingYT/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->